### PR TITLE
Fix bugged verification of emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Inserting a script tag in the bottom of the page (jQuery ready version)...
             case '3':
                 alert('Subscriber email already registered.');
                 break;
+            case '20':
+                alert('Your Email has been successfully removed from our system.');
+                break;
             case '99':
                 alert('Subscriber email not valid.');
                 break;

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -9,3 +9,4 @@ subject: Email from my website     # Subject for confirmation email
 body: Please follow the link to verify your email.
 link: Click Here                   # Link label for confirmation email
 
+path: subscribe 				   # Path to page that contains your subscription signup

--- a/src/NewsletterExtension.php
+++ b/src/NewsletterExtension.php
@@ -125,7 +125,7 @@ class NewsletterExtension extends SimpleExtension
                         'slug'   => 'slug-news' . rand(),
                         'email'  => $nemail,
                         'token'  => $token,
-                        'status' => 'published'
+                        'status' => 'held'
                     ]);
 
                     if ( $repo->save($subscription) !== false ) {

--- a/src/NewsletterExtension.php
+++ b/src/NewsletterExtension.php
@@ -14,7 +14,8 @@ use Bolt\Storage\Entity\Content;
  * 1: Error sending email
  * 2: Error saving subscriber email in DB
  * 3: Subscriber email already registered
- *
+ * 20: Unsubscribed email
+
  * 10: Subscriber email verified
  * 11: Error saving verified email info to DB
  * 12: Error in subscriber email or token sent for verifying
@@ -70,8 +71,16 @@ class NewsletterExtension extends SimpleExtension
                 'token' => $token
             ]);
 
-            if (   $result !== false
+            if (   $result !== false // Record found
                 && ! empty($result->getId() ) ) {
+
+                if ($app['request']->get('unsubscribe') == 'yes') { // Unsubscribe requested - delete the record.
+
+                    $result = $repo->delete($result);
+
+                    return new \Twig_Markup('20', 'UTF-8');
+                }
+
                 $result->setStatus('published');
 
                 if ( $repo->save($result) !== false ) {
@@ -88,7 +97,7 @@ class NewsletterExtension extends SimpleExtension
                 return new \Twig_Markup('12', 'UTF-8');
             }
         }
-        elseif ( $app['request']->getMethod() == 'POST' ) {
+        elseif ( $app['request']->getMethod() == 'POST' ) { // If new subscriber is being added
 
             $nemail = $app['request']->get($config['newsletter_field'] );
 
@@ -112,12 +121,17 @@ class NewsletterExtension extends SimpleExtension
                     'email' => $nemail
                 ]);
 
-                 if (  $result != false
-                    && ! empty($result->getId() ) ) {
-                    // Subscriber email already registered
-                    return new \Twig_Markup('3', 'UTF-8');
+                 if (  $result != false && ! empty($result->getId() ) ) {
+                    if ($result->status == 'published') {
+                        // Subscriber email already registered
+                        return new \Twig_Markup('3', 'UTF-8');
+                    } else {
+                        // Subscriber already exists but is not verified. Delete and Recreate.
+                        $result = $repo->delete($result);
+                    }
+                    
                 }
-                else {
+                
                     $token = '' . rand();
                     $repo  = $app['storage']->getRepository($contenttype);
                     $subscription = new Content([
@@ -130,7 +144,7 @@ class NewsletterExtension extends SimpleExtension
 
                     if ( $repo->save($subscription) !== false ) {
                         $body  = $config['body'];
-                        $body .= '<br><br><a href="' . $app['paths']['rooturl'] . '?email=' . $nemail . '&token=' . $token . '">' . $config['link'] . '</a>';
+                        $body .= '<br><br><a href="' . $app['paths']['rooturl'] . $config['path'] . '?email=' . $nemail . '&token=' . $token . '">' . $config['link'] . '</a>';
 
                         $message = \Swift_Message::newInstance()
                             ->setSubject($config['subject'] )


### PR DESCRIPTION
Fixed subscribers being automatically verified.
Also:
Added unsubscribe function (load the register page with email and token and unsubscribe=yes as get variables)
Added config option for path, in order for the verification and unsubscribe location to be a page other than home
Added functionality for resending the verification email (previously if lost before verification the email registered with cannot be used without admin intervention, although the verification bug bypassed this issue)